### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ EcoGallery
 
 Replacement for Gallery widget in Android with View recycling. This originally made by Joseph Earl ([details](http://stackoverflow.com/a/5882944)). 
 
-##Usage: 
+## Usage: 
 
 1- Include 'EcoGallery' android library to your project. (Eclipse project: properties -> Android -> Library - Add)
 
@@ -31,7 +31,7 @@ Click [here](https://github.com/falnatsheh/EcoGallery/tree/master/EcoGallerySamp
 June 24, 2013 
 - Compiler warnings fixed [@mnowrot](https://github.com/mnowrot)
 
-##Limitation: 
+## Limitation: 
 
 >The existing implementation assumed that each different position in the adapter resulted in a unique view. The changes are only good if your Gallery contains only one type of item, if not you'll need to add some sort of key based on item type and the amount of that type required.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
